### PR TITLE
Removing intl from dependencies

### DIFF
--- a/lib/src/period.dart
+++ b/lib/src/period.dart
@@ -1,5 +1,4 @@
 import 'package:equatable/equatable.dart';
-import 'package:intl/intl.dart';
 import 'package:meta/meta.dart';
 import 'package:time/time.dart';
 
@@ -633,10 +632,10 @@ class Period with EquatableMixin implements Comparable<Period> {
   }
 
   @override
-  String toString({DateFormat? dateFormat}) {
+  String toString({String Function(DateTime date)? dateFormat}) {
     // ignore: no_runtimetype_tostring, simply to print the class
-    return '$runtimeType(${dateFormat?.format(start) ?? start}, '
-        '${dateFormat?.format(end) ?? end})';
+    return '$runtimeType(${dateFormat?.call(start) ?? start}, '
+        '${dateFormat?.call(end) ?? end})';
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,6 @@ environment:
 dependencies:
   collection: '>=1.16.0 <2.0.0'
   equatable: '>=2.0.5 <3.0.0'
-  intl: '>=0.17.0 <0.19.0'
   meta: ^1.11.0
   time: '>=2.1.3 <3.0.0'
 


### PR DESCRIPTION
`intl` should not be on the dependencies of this package since it doesn't actually use it. 